### PR TITLE
Prepare v1.0.2 metadata and final validation summary

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,12 +8,13 @@ authors:
     orcid: "https://orcid.org/0000-0001-5627-579X"
 abstract: >-
   Reproducible group-level analysis of the 13-subject EEGLAB STERN tutorial
-  study, including ERP and time-frequency estimation, quality control, and
-  paired cluster-based permutation statistics.
+  study, including ERP and time-frequency estimation, quality control, paired
+  cluster-based permutation statistics, and auditable final visualizations
+  rendered from validated numerical tables.
 license: "MIT"
 repository-code: "https://github.com/andraderenew/eeg_erps-tf_eeglab-fieldtrip_sternberg"
 url: "https://github.com/andraderenew/eeg_erps-tf_eeglab-fieldtrip_sternberg"
-version: "1.0.1"
+version: "1.0.2"
 date-released: "2026-08-08"
 keywords:
   - "EEG"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ the material reviewed.
 
 ## Citation
 
-Please cite the latest tagged release using [`CITATION.cff`](CITATION.cff).
-The archived `v1.0.0` release remains available at
+Please cite the latest tagged GitHub release using [`CITATION.cff`](CITATION.cff).
+The archived Zenodo `v1.0.0` record remains available at
 [10.5281/zenodo.21826210](https://doi.org/10.5281/zenodo.21826210).
-The Zenodo DOI for `v1.0.1` will be added after Zenodo processes the maintenance release.
+A newer version-specific Zenodo DOI is not stated here until it has been independently confirmed from Zenodo.

--- a/reports/report.md
+++ b/reports/report.md
@@ -17,6 +17,12 @@ ERPs used a −200 to 0 ms baseline. Time-frequency power used four-cycle
 Hanning-window convolution from 4–30 Hz and a −0.48 to −0.16 s dB baseline.
 All 8,192 paired permutations were evaluated.
 
+Final ERP and TF figures were audited separately from the statistical
+computation. Numerical values and corrected-cluster masks are exported to TSV
+before final Matplotlib rendering. TF inferential panels use exact
+channel-specific corrected-cluster masks and exact peak-bin scalp snapshots;
+descriptive sensor averages are kept separate from inferential overlays.
+
 ## Primary ERP result
 
 - Positive cluster, 440–552 ms, 50 channels, corrected p = 0.015869.
@@ -25,24 +31,43 @@ All 8,192 paired permutations were evaluated.
 ## Primary time-frequency result
 
 - Negative cluster, 4–26 Hz and 0.00–1.40 s, 69 channels, corrected p = 0.000610.
+- Exact corrected-cluster peak used for the representative primary TF summary:
+  CP3, 8 Hz, 0.40 s.
+
+## Secondary task-phase results
+
+- Probe − Memorize: negative cluster, 6–30 Hz and 0.00–1.40 s,
+  corrected p < 0.000122.
+- Probe − Ignore: negative cluster, 6–30 Hz and 0.00–1.40 s,
+  corrected p < 0.000122.
 
 ## Interpretation
 
 `Memorize − Ignore` is the primary event-matched letter-onset contrast. Probe
-comparisons are secondary task-phase contrasts.
+comparisons are secondary task-phase contrasts and should not be interpreted as
+pure encoding effects.
+
+Subject-level values extracted from a cluster selected using the same sample
+are reported descriptively as post-selection summaries, not as independent
+confirmatory inference.
 
 ## Quality control
 
 Final ERP and TF arrays contained no non-finite values. Six statistical
-structures and the required public outputs passed final validation.
+structures passed validation. The public visualization set was subsequently
+audited: misleading bounding-box TF topographies and mixed sensor-average/
+cluster-mask displays were replaced by exact-mask/exact-peak summaries, and
+superseded diagnostic figures were removed from the public figure directory.
 
 ## Limitations
 
 The sample contains 13 participants. Cluster inference is cluster-level rather
-than sample-level. Probe contrasts mix task phase and event type. Raw EEG is
-not redistributed.
+than sample-level. Probe contrasts mix task phase and event type. Subject-level
+cluster summaries are post-selection descriptive summaries. Raw EEG is not
+redistributed.
 
 ## Reproducibility
 
-See `scripts/`, `env/TOOL_VERSIONS.md`, `DATA_SOURCES.md`, and
-`results/summaries/stern_final_validation.txt`.
+See `scripts/`, `env/TOOL_VERSIONS.md`, `DATA_SOURCES.md`,
+`results/summaries/stern_final_validation.txt`, and
+`results/summaries/stern_tf_visualization_redesign_summary.txt`.

--- a/results/summaries/stern_final_validation.txt
+++ b/results/summaries/stern_final_validation.txt
@@ -1,19 +1,39 @@
-=== STERN FINAL SCIENTIFIC VALIDATION ===
+=== STERN FINAL SCIENTIFIC VALIDATION — v1.0.2 PREP ===
 ERP array size: [3 13 69 151]
 ERP non-finite values: 0
 TF array size: [3 13 69 14 50]
 TF non-finite values: 0
 Statistical MAT files validated: 6
-Required final tables validated: 5
-Required final figures validated: 15
-ERP corrected significant clusters: 12
+ERP corrected significant clusters across stored contrasts: 12
 Primary TF corrected significant clusters: 1
 Secondary TF corrected significant clusters: 2
-Primary TF subject-effect rows: 13
+
+Final auditable visualization sources:
+ERP waveform source tables: 2
+TF visualization source tables: 7
+Current public PNG figures after visual audit: 8
+
+Primary TF visualization audit:
+Corrected cluster p: 0.000610351562
+Exact corrected-cluster peak: CP3, 8 Hz, 0.40 s
+Peak t statistic: -7.621061009
+Corrected-cluster active channels across its full extent: 69/69
+Old bounding-rectangle channel-frequency-time fill: 22.930%
+Old bounding-box TF topography: retired
+Mixed sensor-average + any-channel inferential overlay: retired
+Final inferential display: exact channel-specific mask + exact peak-bin scalp snapshot
+
+Secondary TF visualization audit:
+Probe - Memorize and Probe - Ignore use exact peak snapshots and channel-specific corrected-cluster masks.
+Common symmetric scales are used for visual comparison between the two secondary contrasts.
+Superseded secondary sensor-average/topography displays were retired.
 
 Interpretation constraints:
 Memorize - Ignore is the primary event-matched letter-onset comparison.
 Probe comparisons are secondary task-phase contrasts and are not pure encoding contrasts.
 Cluster significance applies to connected sample sets, not to each sample independently.
+Subject-level values extracted from a cluster selected on the same sample are descriptive post-selection summaries, not independent confirmatory tests.
+Descriptive sensor averages are not overlaid with corrected-cluster masks in the final inferential figures.
 
-VALIDATION PASSED
+VISUALIZATION AUDIT PASSED
+SCIENTIFIC RESULTS AND CLUSTER-PERMUTATION STATISTICS UNCHANGED


### PR DESCRIPTION
Release-preparation cleanup after the ERP/TF visualization audit.

This PR:
- updates CITATION.cff to version 1.0.2;
- updates the scientific report to describe the audited exact-mask/exact-peak TF visualization strategy and post-selection interpretation limits;
- refreshes the final validation summary to match the current 8-PNG public figure set and 7 auditable TF visualization tables;
- removes the stale README statement that a v1.0.1 Zenodo DOI would be added automatically, while preserving the confirmed v1.0.0 Zenodo DOI.

No numerical analysis, TFR computation, permutation statistic, cluster result, or figure is changed in this PR.